### PR TITLE
Add JSON-RPC Support to args

### DIFF
--- a/examples/json-rpc-client.go
+++ b/examples/json-rpc-client.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"fmt"
+
+	"net/rpc/jsonrpc"
+	"net/url"
+	"os"
+
+	"net"
+
+	"github.com/pkg/errors"
+	"github.com/thrawn01/args"
+)
+
+func getEndpoint(opts *args.Options, endpoint *string) error {
+	*endpoint = opts.String("endpoint")
+	_, err := url.Parse(*endpoint)
+	if err != nil {
+		return errors.Wrapf(err, "url endpoint '%s' is invalid", *endpoint, err.Error())
+	}
+	return nil
+}
+
+// TODO: Rewrite this to use args.JsonRPCClient()
+
+func main() {
+	parser := args.NewParser(args.Name("http-client"),
+		args.Desc("Example http client client"))
+
+	parser.AddOption("--verbose").Alias("-v").Count().Help("Be verbose")
+	parser.AddOption("--endpoint").Default("http://localhost:1234/config").
+		Help("The JSON-RPC endpoint our client will talk too")
+
+	parser.AddCommand("list", list)
+	parser.AddCommand("get", get)
+	parser.AddCommand("set", set)
+
+	// Run the command chosen by the user
+	retCode, err := parser.ParseAndRun(nil, nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+	os.Exit(retCode)
+}
+
+func list(subParser *args.ArgParser, data interface{}) int {
+	opts := subParser.GetOpts()
+	var values []string
+	var url string
+
+	if err := getEndpoint(opts, &url); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	conn, err := net.Dial("tcp", url)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer conn.Close()
+
+	client := jsonrpc.NewClient(conn)
+
+	// List will return all keys that match the prefix passed
+	err = client.Call("list", "root", &values)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Printf("%v\n", values)
+	return 0
+}
+
+func get(subParser *args.ArgParser, data interface{}) int {
+	opts := subParser.GetOpts()
+	var value string
+	var url string
+
+	if err := getEndpoint(opts, &url); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	conn, err := net.Dial("tcp", url)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer conn.Close()
+
+	client := jsonrpc.NewClient(conn)
+
+	// List will return all keys that match the prefix passed
+	err = client.Call("get", "root", &value)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	fmt.Printf("%v\n", value)
+	return 0
+}
+
+func set(subParser *args.ArgParser, data interface{}) int {
+	opts := subParser.GetOpts()
+	var reply int
+	var url string
+
+	if err := getEndpoint(opts, &url); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	conn, err := net.Dial("tcp", url)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	defer conn.Close()
+
+	client := jsonrpc.NewClient(conn)
+
+	// List will return all keys that match the prefix passed
+	err = client.Call("set", []string{"key", "value"}, &reply)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if reply != 0 {
+		fmt.Fprintf(os.Stderr, "'%s'='%s' failed\n", "key", "value")
+		return 1
+	}
+	fmt.Printf("'%s'='%s' set successfully\n", "key", "value")
+	return 0
+}

--- a/examples/json-rpc-server.go
+++ b/examples/json-rpc-server.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/thrawn01/args"
+)
+
+func main() {
+	parser := args.NewParser(args.Desc("Demo Service showcasing args JSON-RPC interface"))
+	parser.AddOption("--bind").Alias("-b").Env("BIND").
+		Default("0.0.0.0:1234").Help("The interface to bind too")
+
+	parser.AddOption("--power-level").Alias("-p").Default("10000").IsInt().
+		Help("set our power level")
+
+	parser.AddConfig("simple").Help("Demo of simple config item")
+
+	// Since args does not natively support deeply nested structured data, we can fake it by using nested keys
+	// Much like etcdv3 uses prefix matching to support deeply nested structures
+	parser.AddConfig("root/sub/item1").Help("nested key demo1")
+	parser.AddConfig("root/sub/item2").Help("nested key demo2")
+	parser.AddConfig("root/sub/item3").Help("nested key demo3")
+
+	// Config groups are accessed via th JSON-RPC interface just like nest keys
+	parser.AddConfigGroup("endpoints").Help("Demo of a config group")
+
+	opt := parser.ParseArgsSimple(nil)
+
+	// Simple Application that just displays our current config
+	http.HandleFunc("/my-app", func(w http.ResponseWriter, r *http.Request) {
+		conf := parser.GetOpts()
+
+		payload, err := json.Marshal(map[string]string{
+			"bind":           conf.String("bind"),
+			"power-level":    conf.Int("power-level"),
+			"simple":         conf.String("simple"),
+			"root/sub/item1": conf.String("root/sub/item1"),
+			"root/sub/item2": conf.String("root/sub/item2"),
+			"root/sub/item3": conf.String("root/sub/item3"),
+			"endpoints":      conf.StringSlice("endpoints"),
+		})
+		if err != nil {
+			fmt.Println("error:", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(payload)
+	})
+
+	// Allow external users to change our config remotely via the JSON-RPC handler
+	http.HandleFunc("/config", parser.JsonRPCHandler)
+
+	fmt.Printf("Listening on %s...\n", opt.String("bind"))
+	log.Fatal(http.ListenAndServe(opt.String("bind"), nil))
+
+}

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -1,0 +1,18 @@
+package args
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// This method exposes the args.RPC interface via JSON-RPC
+func (self *ArgParser) JsonRPCHandler(resp http.ResponseWriter, req *http.Request) {
+
+	// Decode the JSON Request
+
+	// Execute the Method
+
+	// Encode the response
+
+	fmt.Fprintf(resp, `{ "message": "JSON RPC HERE"}`)
+}


### PR DESCRIPTION
# Proposal

To provide users with an http.Handler to expose to operations administrators access to the applications internal configuration.  
# Rational

This provides microservices the capability of being remotely configured in environments where a config store like ETCD, or ZOOKEEPER does not exist. It can also be used by monitoring to validate service configurations. 
