### PR TITLE
Added new map parser,

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -191,6 +191,26 @@ var _ = Describe("ArgParser", func() {
 			_, err := parser.Apply(options)
 			Expect(err).To(Not(BeNil()))
 		})
+		It("Should not error if key contains non alpha char", func() {
+			parser := args.NewParser()
+			parser.AddOption("--map").IsStringMap()
+			parser.AddOption("--foo")
+
+			cmdLine := []string{"--map", "http.ip=192.168.1.1"}
+			opt, err := parser.ParseArgs(&cmdLine)
+			Expect(opt.StringMap("map")).To(Equal(map[string]string{"http.ip": "192.168.1.1"}))
+			Expect(err).To(BeNil())
+		})
+		It("Should not error if key or value contains an escaped equal or comma", func() {
+			parser := args.NewParser()
+			parser.AddOption("--map").IsStringMap()
+			parser.AddOption("--foo")
+
+			cmdLine := []string{"--map", `http\=ip=192.168.1.1`}
+			opt, err := parser.ParseArgs(&cmdLine)
+			Expect(err).To(BeNil())
+			Expect(opt.StringMap("map")).To(Equal(map[string]string{"http=ip": "192.168.1.1"}))
+		})
 		It("Should error not error if no map value is supplied", func() {
 			parser := args.NewParser()
 			parser.AddOption("--list").IsStringMap()
@@ -296,10 +316,6 @@ var _ = Describe("ArgParser", func() {
 			Expect(err).To(Not(BeNil()))
 
 			cmdLine = []string{"--map", "belt="}
-			opt, err = parser.ParseArgs(&cmdLine)
-			Expect(err).To(Not(BeNil()))
-
-			cmdLine = []string{"--map", "belt=blue;"}
 			opt, err = parser.ParseArgs(&cmdLine)
 			Expect(err).To(Not(BeNil()))
 
@@ -458,17 +474,6 @@ var _ = Describe("ArgParser", func() {
 			Expect(err).To(Not(BeNil()))
 			Expect(err.Error()).To(Equal("'second' is ambiguous when " +
 				"following greedy argument 'first'"))
-		})
-		It("Should respect escaped sequences in arguments", func() {
-			parser := args.NewParser()
-			parser.AddOption("--me").IsTrue()
-			parser.AddArgument("first").Required()
-
-			cmdLine := []string{"\\-\\-me"}
-			opts, err := parser.ParseArgs(&cmdLine)
-			Expect(err).To(BeNil())
-			Expect(opts.String("first")).To(Equal("--me"))
-			Expect(opts.Bool("me")).To(Equal(false))
 		})
 	})
 	Describe("ArgParser.AddConfig()", func() {

--- a/rules.go
+++ b/rules.go
@@ -162,16 +162,12 @@ func (self *Rule) Match(args []string, idx *int) (bool, error) {
 	}
 
 	// If we get here, this argument is associated with either an option value or an positional argument
-	value, err := self.Cast(name, self.Value, self.UnEscape(args[*idx]))
+	value, err := self.Cast(name, self.Value, args[*idx])
 	if err != nil {
 		return true, err
 	}
 	self.Value = value
 	return true, nil
-}
-
-func (self *Rule) UnEscape(str string) string {
-	return strings.Replace(str, "\\", "", -1)
 }
 
 // Returns the appropriate required warning to display to the user

--- a/rules_test.go
+++ b/rules_test.go
@@ -7,14 +7,6 @@ import (
 )
 
 var _ = Describe("Rule", func() {
-	Describe("Rule.UnEscape()", func() {
-		It("Should unescape strings with black slash's", func() {
-			rule := &args.Rule{}
-			Expect(rule.UnEscape("\\-\\-help")).To(Equal("--help"))
-			Expect(rule.UnEscape("--help")).To(Equal("--help"))
-		})
-	})
-
 	Describe("Rule.SetFlags()", func() {
 		It("Should set the proper flags", func() {
 			rule := &args.Rule{}

--- a/tokenizer.go
+++ b/tokenizer.go
@@ -1,0 +1,56 @@
+package args
+
+import "strings"
+
+// Given a string a `key=value,key=value` and
+// successive calls to Next() will return `key` then `=`
+// then `value` then `,` etc, etc....
+type KeyValueTokenizer struct {
+	Buffer   string
+	Pos      int
+	nextRune rune
+}
+
+func NewKeyValueTokenizer(source string) *KeyValueTokenizer {
+	return &KeyValueTokenizer{
+		Buffer: source,
+	}
+}
+
+// Return the next token found
+func (t *KeyValueTokenizer) Next() string {
+	// No more tokens to find
+	if t.Pos >= len(t.Buffer) {
+		return ""
+	}
+	for i := t.Pos; i < len(t.Buffer); i++ {
+		char := t.Buffer[i]
+		if char == '=' || char == ',' {
+			// It's an escaped delimiter
+			if !(i-1 <= 0) && t.Buffer[i-1] == '\\' {
+				// As long as the escape was not escaped =)
+				if !((i - 2) <= 0) && t.Buffer[i-2] != '\\' {
+					// Remove the escape
+					t.Buffer = t.Buffer[:i-1] + t.Buffer[i:]
+					// Account for the deleted escape
+					i -= 1
+					// And skip this delimiter
+					continue
+				}
+			}
+			var token string
+			if i == t.Pos {
+				token = string(t.Buffer[i])
+				t.Pos += 1
+			} else {
+				token = strings.TrimSpace(string(t.Buffer[t.Pos:i]))
+				t.Pos = i
+			}
+			return token
+		}
+	}
+	// If we get here, we are at the end of our buffer. Nothing more to tokenize
+	token := strings.TrimSpace(t.Buffer[t.Pos:])
+	t.Pos = len(t.Buffer)
+	return token
+}

--- a/tokenizer_test.go
+++ b/tokenizer_test.go
@@ -1,0 +1,114 @@
+package args_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/thrawn01/args"
+)
+
+var _ = Describe("KeyValueTokenizer", func() {
+
+	Describe("Next()", func() {
+		Context("Given a single key=value pair", func() {
+			It("Should return the next token found in the buffer", func() {
+				tokenizer := args.NewKeyValueTokenizer("key=value")
+
+				Expect(tokenizer.Next()).To(Equal("key"))
+				Expect(tokenizer.Next()).To(Equal("="))
+				Expect(tokenizer.Next()).To(Equal("value"))
+				Expect(tokenizer.Next()).To(Equal(""))
+				// Should not error
+				Expect(tokenizer.Next()).To(Equal(""))
+			})
+		})
+		Context("Given multiple key=value pairs", func() {
+			It("Should return the next token found in the buffer", func() {
+				tokenizer := args.NewKeyValueTokenizer("key=value,key2=value2")
+
+				Expect(tokenizer.Next()).To(Equal("key"))
+				Expect(tokenizer.Next()).To(Equal("="))
+				Expect(tokenizer.Next()).To(Equal("value"))
+				Expect(tokenizer.Next()).To(Equal(","))
+				Expect(tokenizer.Next()).To(Equal("key2"))
+				Expect(tokenizer.Next()).To(Equal("="))
+				Expect(tokenizer.Next()).To(Equal("value2"))
+				Expect(tokenizer.Next()).To(Equal(""))
+				// Should not error
+				Expect(tokenizer.Next()).To(Equal(""))
+			})
+		})
+		Context("Given multiple key=value pairs with prefix and suffic space", func() {
+			It("Should return the next token found in the buffer without the spaces", func() {
+				tokenizer := args.NewKeyValueTokenizer("key =value , key2= value2")
+
+				Expect(tokenizer.Next()).To(Equal("key"))
+				Expect(tokenizer.Next()).To(Equal("="))
+				Expect(tokenizer.Next()).To(Equal("value"))
+				Expect(tokenizer.Next()).To(Equal(","))
+				Expect(tokenizer.Next()).To(Equal("key2"))
+				Expect(tokenizer.Next()).To(Equal("="))
+				Expect(tokenizer.Next()).To(Equal("value2"))
+				Expect(tokenizer.Next()).To(Equal(""))
+				// Should not error
+				Expect(tokenizer.Next()).To(Equal(""))
+			})
+		})
+		Context(`Given an escaped delimiter key\==value`, func() {
+			It("Should respect the escaped delimiter", func() {
+				tokenizer := args.NewKeyValueTokenizer(`http\=ip=value\=`)
+
+				Expect(tokenizer.Next()).To(Equal(`http=ip`))
+				Expect(tokenizer.Next()).To(Equal("="))
+				Expect(tokenizer.Next()).To(Equal("value="))
+				Expect(tokenizer.Next()).To(Equal(""))
+				// Should not error
+				Expect(tokenizer.Next()).To(Equal(""))
+
+				tokenizer = args.NewKeyValueTokenizer(`key\,=value\=`)
+
+				Expect(tokenizer.Next()).To(Equal(`key,`))
+				Expect(tokenizer.Next()).To(Equal("="))
+				Expect(tokenizer.Next()).To(Equal("value="))
+				Expect(tokenizer.Next()).To(Equal(""))
+				// Should not error
+				Expect(tokenizer.Next()).To(Equal(""))
+			})
+		})
+		Context(`Given an escaped escaped delimiter key\\=value`, func() {
+			It("Should respect the escaped escaped delimiter", func() {
+				tokenizer := args.NewKeyValueTokenizer(`key\\=value`)
+
+				Expect(tokenizer.Next()).To(Equal(`key\\`))
+				Expect(tokenizer.Next()).To(Equal("="))
+				Expect(tokenizer.Next()).To(Equal("value"))
+				Expect(tokenizer.Next()).To(Equal(""))
+				// Should not error
+				Expect(tokenizer.Next()).To(Equal(""))
+			})
+		})
+		Context("Given malformed buffer", func() {
+			It("Should return a valid token", func() {
+				tokenizer := args.NewKeyValueTokenizer("value")
+				Expect(tokenizer.Next()).To(Equal("value"))
+				Expect(tokenizer.Next()).To(Equal(""))
+
+				tokenizer = args.NewKeyValueTokenizer(",")
+				Expect(tokenizer.Next()).To(Equal(","))
+				Expect(tokenizer.Next()).To(Equal(""))
+
+				tokenizer = args.NewKeyValueTokenizer("=")
+				Expect(tokenizer.Next()).To(Equal("="))
+				Expect(tokenizer.Next()).To(Equal(""))
+
+				tokenizer = args.NewKeyValueTokenizer("=,")
+				Expect(tokenizer.Next()).To(Equal("="))
+				Expect(tokenizer.Next()).To(Equal(","))
+				Expect(tokenizer.Next()).To(Equal(""))
+
+				tokenizer = args.NewKeyValueTokenizer(`{"blue":"bell"}`)
+				Expect(tokenizer.Next()).To(Equal(`{"blue":"bell"}`))
+				Expect(tokenizer.Next()).To(Equal(""))
+			})
+		})
+	})
+})


### PR DESCRIPTION
## Purpose
* Users can now pass in map keys and values like `http.ip=192.168.1.1`  and `http\,ip=192.168.1.1` with receiving an error
* The ability to pass in a argument that resembles a flag by escaping the value like so `\-\-help` is ambiguous as the user might also want to pass in `\nhelp` which with current code would not be allowed

## Implementation
* Added a new struct `KeyValueTokenizer{}` to parse and tokenize the map key=values
* Removed `rule.Unescape()`