### PR TITLE
Allow the user to determine how a value was chosen by the parser

### DIFF
--- a/options.go
+++ b/options.go
@@ -267,6 +267,8 @@ func (self *Options) KeySlice(key string) []string {
 	return self.Group(key).Keys()
 }
 
+// Returns true if the argument value is set.
+// Use IsDefault(), IsEnv(), IsArg() to determine how the parser set the value
 func (self *Options) IsSet(key string) bool {
 	if opt, ok := self.values[key]; ok {
 		rule := opt.GetRule()
@@ -278,13 +280,50 @@ func (self *Options) IsSet(key string) bool {
 	return false
 }
 
-func (self *Options) IsSeen(key string) bool {
+// Returns true if this argument is set via the environment
+func (self *Options) IsEnv(key string) bool {
+	if opt, ok := self.values[key]; ok {
+		rule := opt.GetRule()
+		if rule == nil {
+			return false
+		}
+		return (rule.Flags&EnvValue != 0)
+	}
+	return false
+}
+
+// Returns true if this argument is set via the command line
+func (self *Options) IsArg(key string) bool {
 	if opt, ok := self.values[key]; ok {
 		rule := opt.GetRule()
 		if rule == nil {
 			return false
 		}
 		return (rule.Flags&Seen != 0)
+	}
+	return false
+}
+
+// Returns true if this argument is set via the default value
+func (self *Options) IsDefault(key string) bool {
+	if opt, ok := self.values[key]; ok {
+		rule := opt.GetRule()
+		if rule == nil {
+			return false
+		}
+		return (rule.Flags&DefaultValue != 0)
+	}
+	return false
+}
+
+// Returns true if this argument was set via the command line or was set by an environment variable
+func (self *Options) WasSeen(key string) bool {
+	if opt, ok := self.values[key]; ok {
+		rule := opt.GetRule()
+		if rule == nil {
+			return false
+		}
+		return (rule.Flags&Seen != 0) || (rule.Flags&EnvValue != 0)
 	}
 	return false
 }

--- a/rules.go
+++ b/rules.go
@@ -29,6 +29,8 @@ const (
 	IsFormated
 	IsGreedy
 	NoValue
+	DefaultValue
+	EnvValue
 	Seen
 )
 
@@ -199,6 +201,7 @@ func (self *Rule) ComputedValue(values *Options) (interface{}, error) {
 	}
 
 	if value != nil {
+		self.SetFlag(EnvValue)
 		return value, nil
 	}
 
@@ -218,6 +221,7 @@ func (self *Rule) ComputedValue(values *Options) (interface{}, error) {
 
 	// Apply default if available
 	if self.Default != nil {
+		self.SetFlag(DefaultValue)
 		return self.Cast(self.Name, self.Value, *self.Default)
 	}
 


### PR DESCRIPTION
## Purpose
Users might want insight into how a value was chosen by the parser. 
```go
// If 'http' is true and was not set via the cli or the environment
if opts.Bool("http") && !opts.WasSeen("endpoint") {
	opts.Set("endpoint", "http://localhost:19092")
}
```

## Implementation
* Added `IsDefault()` returns true if the arg was set via default value
* Added `IsArg()` returns true if the arg was set via cli
* Added `IsEnv()` returns true if the arg was set via environment
* Renamed `IsSeen()` to `WasSeen()` 
* `WasSeen()` now returns true if the argument was seen on the command line or in the environment