### PR TITLE
Added parser.GetRule()

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -218,8 +218,29 @@ func (self *ArgParser) AddRule(name string, modifier *RuleModifier) *RuleModifie
 	return modifier
 }
 
+// Returns the current list of rules for this parser. If you want to modify a rule
+// use GetRule() instead.
 func (self *ArgParser) GetRules() Rules {
 	return self.rules
+}
+
+// Allow the user to modify an existing parser rule
+//	parser := args.NewParser()
+//	parser.AddOption("--endpoint").Default("http://localhost:19092")
+//	parser.AddOption("--grpc").IsTrue()
+// 	opts := parser.ParseArgsSimple(nil)
+//
+//	if opts.Bool("grpc") && !opts.WasSeen("endpoint") {
+//		parser.GetRule("endpoint").SetDefault("localhost:19091")
+//		opts = parser.ParseArgsSimple(nil)
+//	}
+func (self *ArgParser) GetRule(name string) *RuleModifier {
+	for _, rule := range self.rules {
+		if rule.Name == name {
+			return newRuleModifier(rule, self)
+		}
+	}
+	return nil
 }
 
 func (self *ArgParser) ParseAndRun(args *[]string, data interface{}) (int, error) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -367,6 +367,20 @@ var _ = Describe("ArgParser", func() {
 			Expect(opt.String("first")).To(Equal("one"))
 		})
 	})
+	Describe("ArgParser.GetRule()", func() {
+		It("Should return allow user to modify an existing rule ", func() {
+			parser := args.NewParser()
+			parser.AddOption("first").IsString().Default("one")
+			opt, err := parser.ParseArgs(nil)
+			Expect(err).To(BeNil())
+			Expect(opt.String("first")).To(Equal("one"))
+			// Modify the rule and parse again
+			parser.GetRule("first").Default("two")
+			opt, err = parser.ParseArgs(nil)
+			Expect(err).To(BeNil())
+			Expect(opt.String("first")).To(Equal("two"))
+		})
+	})
 
 	Describe("ArgParser.AddArgument()", func() {
 		cmdLine := []string{"one", "two", "three", "four"}


### PR DESCRIPTION
## Purpose
Allow users to modify a rule that has already been added
```go
parser := args.NewParser()
parser.AddOption("--endpoint").Default("http://localhost:19092")
parser.AddOption("--grpc").IsTrue()
opts := parser.ParseArgsSimple(nil)

if opts.Bool("grpc") && !opts.WasSeen("endpoint") {
	parser.GetRule("endpoint").SetDefault("localhost:19091")
        opts = parser.ParseArgsSimple(nil)
}
```
## Implementation
* Added `GetRule()`