### PR TITLE
Refactor backend code

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A cloud native app configuration and argument parser designed for
 Configuration for modern cloud native applications is divided into two separate
 phases. The first phase is initialization, This is the minimum configuration
 the service needs to start up. At a minimum this may include configuration for:
-Service Interface, Port Number, TLS Certs, and the source location of the
+Service Interface, Port Number, and the source location of the
 second phase configuration.
 
 The second phase includes everything else the service needs to operate.
@@ -30,16 +30,10 @@ Args as a project has the following goals
 2. Backend config watchers. Args should provide an interface to plugin key/value stores
    such as etcd and zookeeper with helper functions designed to make updating
    your local config super simple.
-3. Built in JSON-RPC http handler. Some applications can't utilize external
-   config systems like kubernetes or etcd for second phase configuration. Args
-   should provide a JSON-RPC interface you can expose on a http route of your
-   choosing which will allow admins to modify the configuration while the
-   service is running. This makes your application cloud native without a hard
-   requirement on external systems.
-4. Easy to use subcommand support. I have years of experience using and writing
+3. Easy to use subcommand support. I have years of experience using and writing
    subcommand like tools. Take my lessions learned and apply them here. [See
    subcommand.org](http://subcommand.org)
-5. The relationship between, Environment, Commandline, and Config should NOT
+4. The relationship between, Environment, Commandline, and Config should NOT
    result in impedance mismatch. If a feature would result in an imedance
    mismatch the feature will be rejected. This results in args being somewhat
    opinionated. However, for the operators sake, cloud native applications
@@ -82,7 +76,7 @@ parser.AddConfig("some-key").Alias("-k").Default("default-key").
     Help("A fake api-key")
 
 // Parses the commandline, calls os.Exit(1) if there is an error
-opts := parser.ParseArgsSimple(nil)
+opts := parser.ParseOrExit(nil)
 
 // Simple handler that returns some-key
 http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -102,7 +96,7 @@ http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 ## Watch key store backends for config changes
 Args supports additional backend configuration via any backend that implements the
  ```Backend``` interface. Currently only etcd is supported and is provided by the
-  [args-backend](http://github.com/thrawn01/args-backends) repo.
+  [args-etcd](http://github.com/thrawn01/args-etcd) repo.
 
 ```go
 // -- snip ---
@@ -114,16 +108,16 @@ if err != nil {
     log.Fatal(err)
 }
 
-etcdBackend := backends.NewEtcdBackend(client, "/etcd-endpoints-service")
+backend := backends.NewV3Backend(client, "/etcd-endpoints-service")
 
 // Read all the available config values from etcd
-opts, err = parser.FromBackend(etcdBackend)
+opts, err = parser.FromBackend(backend)
 if err != nil {
     fmt.Printf("Etcd error - %s\n", err.Error())
 }
 
 // Watch etcd for any configuration changes (This starts a go routine)
-cancelWatch := etcdBackend.Watch(client, func(event args.ChangeEvent, err error) {
+cancelWatch := parser.Watch(backend, func(event args.ChangeEvent, err error) {
     if err != nil {
         fmt.Println(err.Error())
         return
@@ -182,7 +176,7 @@ func show(subParser *args.ArgParser, data interface{}) int {
 
 func createVolume(subParser *args.ArgParser, data interface{}) int {
     subParser.AddArgument("name").Required().Help("The name of the volume to create")
-    opts, err := subParser.ParseArgs(nil)
+    opts, err := subParser.Parse(nil)
     if err != nil {
         fmt.Println(err.Error())
         return 1
@@ -204,7 +198,7 @@ with Kubernetes ConfigMap**
 ```go
     parser := args.NewParser()
     parser.AddOption("--config").Alias("-c").Help("Read options from a config file")
-    opt := parser.ParseArgsSimple(nil)
+    opt := parser.ParseSimple(nil)
     configFile := opt.String("config")
     // Initial load of our config file
     opt, err = parser.FromIniFile(configFile)
@@ -233,246 +227,7 @@ with Kubernetes ConfigMap**
 ## Demo Code Examples
 See more code examples in the ```examples/``` directory
 
-```go
-package main
 
-import (
-    "fmt"
-    "os"
-
-    "github.com/thrawn01/args"
-)
-
-type Config struct {
-    PowerLevel  int
-    Message     string
-    StringSlice []string
-    Verbose     int
-    DbHost      string
-    TheQuestion string
-    TheAnswer   int
-}
-
-func main() {
-    var conf Config
-
-    // Create the parser with program name 'example'
-    // and environment variables prefixed with APP_
-    parser := args.NewParser(args.Name("demo"), args.EnvPrefix("APP_"),
-        args.Desc("This is a demo app to showcase some features of args"))
-
-    // Store Integers directly into a struct with a default value
-    parser.AddOption("--power-level").Alias("-p").StoreInt(&conf.PowerLevel).
-        Env("POWER_LEVEL").Default("10000").Help("set our power level")
-
-    // Command line options can begin with -name, --name or even ++name
-    // Most non word characters are supported
-    parser.AddOption("++config-file").Alias("+c").IsString().
-        Default("/path/to/config").Help("path to config file")
-
-    // Use the args.Env() function to define an environment variable
-    // NOTE: Since the parser was passed args.EnvPrefix("APP_") the actual
-    // environment variable name is 'APP_MESSAGE'
-    parser.AddOption("--message").Alias("-m").StoreStr(&conf.Message).
-        Env("MESSAGE").Default("over-ten-thousand").Help("send a message")
-
-    // Pass a comma separated list of strings and get a []string slice
-    parser.AddOption("--slice").Alias("-s").StoreStringSlice(&conf.StringSlice).Env("LIST").
-        Default("one,two,three").Help("list of messages")
-
-    // Count the number of times an option is seen
-    parser.AddOption("--verbose").Alias("-v").Count().StoreInt(&conf.Verbose).Help("be verbose")
-
-    // Set bool to true if the option is present on the command line
-    parser.AddOption("--debug").Alias("-d").IsTrue().Help("turn on Debug")
-
-    // Specify the type of the arg with IsInt(), IsString(), IsBool() or IsTrue()
-    parser.AddOption("--help").Alias("-h").IsTrue().Help("show this help message")
-
-    // Add Required argument
-    parser.AddArgument("the-question").Required().
-        StoreStr(&conf.TheQuestion).Help("Before you have an answer")
-
-    // Add Optional arguments
-    parser.AddArgument("the-answer").IsInt().Default("42").
-        StoreInt(&conf.TheAnswer).Help("It must be 42")
-
-    // Greedy arguments (my-prog lie1 lie2) becomes []string{"lie1", "lie2"}
-    parser.AddArgument("lies").IsStringSlice().Help("lots of lies in a []string")
-
-    // 'Conf' options are not set via the command line but can be set
-    // via a config file or an environment variable
-    parser.AddConfig("twelve-factor").Env("TWELVE_FACTOR").Help("Demo of config options")
-
-    // Define a 'database' subgroup
-    db := parser.InGroup("database")
-
-    // Add command line options to the subgroup
-    db.AddOption("--host").Alias("-dH").StoreStr(&conf.DbHost).
-        Default("localhost").Help("database hostname")
-
-    // Add subgroup specific config. 'Conf' options are not set via the
-    // command line but can be set via a config file or anything that calls parser.Apply()
-    db.AddConfig("debug").IsTrue().Help("enable database debug")
-
-    // 'Conf' option names are not allowed to start with a non word character like
-    // '--' or '++' so they can not be confused with command line options
-    db.AddConfig("database").IsString().Default("myDatabase").Help("name of database to use")
-
-    // If no type is specified, defaults to 'IsString'
-    db.AddConfig("user").Help("database user")
-    db.AddConfig("pass").Help("database password")
-
-    // Pass our own argument list, or nil to parse os.Args[]
-    opt := parser.ParseArgsSimple(nil)
-
-    // NOTE: ParseArgsSimple() is just a convenience, you can call
-    // parser.ParseArgs(nil) directly and handle the errors
-    // yourself if you have more complicated use case
-
-    // Demo default variables in a struct
-    fmt.Printf("Power        '%d'\n", conf.PowerLevel)
-    fmt.Printf("Message      '%s'\n", conf.Message)
-    fmt.Printf("String Slice '%s'\n", conf.StringSlice)
-    fmt.Printf("DbHost       '%s'\n", conf.DbHost)
-    fmt.Printf("TheAnswer    '%d'\n", conf.TheAnswer)
-    fmt.Println("")
-
-    // If user asked for --help or there were no options passed
-    if opt.NoArgs() || opt.Bool("help") {
-        parser.PrintHelp()
-        os.Exit(-1)
-    }
-
-    fmt.Println("")
-    fmt.Println("==================")
-    fmt.Println(" Direct Cast")
-    fmt.Println("==================")
-
-    // Fetch values by using the Cast functions
-    fmt.Printf("Power               '%d'\n", opt.Int("power-level"))
-    fmt.Printf("Message             '%s'\n", opt.String("message"))
-    fmt.Printf("String Slice        '%s'\n", opt.StringSlice("slice"))
-    fmt.Printf("String Slice Lies   '%s'\n", opt.StringSlice("lies"))
-    fmt.Printf("Verbose             '%d'\n", opt.Int("verbose"))
-    fmt.Printf("Debug               '%t'\n", opt.Bool("debug"))
-    fmt.Printf("TheAnswer           '%d'\n", opt.Int("the-answer"))
-    fmt.Printf("TheAnswer as String '%s'\n", opt.String("the-answer"))
-
-    fmt.Println("")
-    fmt.Println("==================")
-    fmt.Println(" Database Group")
-    fmt.Println("==================")
-
-    // Fetch Group values
-    dbAddOption := opt.Group("database")
-    fmt.Printf("CAST DB Host   '%s'\n", dbAddOption.String("host"))
-    fmt.Printf("CAST DB Debug  '%t'\n", dbAddOption.Bool("debug"))
-    fmt.Printf("CAST DB User   '%s'\n", dbAddOption.String("user"))
-    fmt.Printf("CAST DB Pass   '%s'\n", dbAddOption.String("pass"))
-
-    fmt.Println("")
-
-    iniFile := []byte(`
-        power-level=20000
-        message=OVER-TEN-THOUSAND!
-        slice=three,four,five,six
-        verbose=5
-        debug=true
-
-        [database]
-        debug=false
-        host=mysql.thrawn01.org
-        user=my-username
-        pass=my-password
-    `)
-
-    // Make configuration simple by reading arguments from an INI file
-    opt, err := parser.FromIni(iniFile)
-    if err != nil {
-        fmt.Println(err.Error())
-        os.Exit(-1)
-    }
-
-    fmt.Println("")
-    fmt.Println("==================")
-    fmt.Println("From INI file")
-    fmt.Println("==================")
-
-    // Values from the config file are used only if the argument is not present
-    // on the commandline
-    fmt.Printf("INI Power      '%d'\n", conf.PowerLevel)
-    fmt.Printf("INI Message    '%s'\n", conf.Message)
-    fmt.Printf("INI Slice      '%s'\n", conf.StringSlice)
-    fmt.Printf("INI Verbose    '%d'\n", conf.Verbose)
-    fmt.Printf("INI Debug      '%t'\n", opt.Bool("debug"))
-    fmt.Println("")
-}
-```
-
-Running this program produces this output
-
-```
-$ bin/demo why 50
-Power        '10000'
-Message      'over-ten-thousand'
-String Slice '[one two three]'
-DbHost       'localhost'
-TheAnswer    '50'
-
-
-==================
- Direct Cast
-==================
-Power               '10000'
-Message             'over-ten-thousand'
-String Slice        '[one two three]'
-Verbose             '0'
-Debug               'false'
-TheAnswer           '50'
-TheAnswer as String '50'
-
-==================
- Database Group
-==================
-CAST DB Host   'localhost'
-CAST DB Debug  'false'
-CAST DB User   ''
-CAST DB Pass   ''
-
-
-==================
-From INI file
-==================
-INI Power      '20000'
-INI Message    'OVER-TEN-THOUSAND!'
-INI Slice      '[three four five six]'
-INI Verbose    '5'
-INI Debug      'true'
-```
-
-Here is the help message
-```
-$ bin/demo -h
-Usage: demo [OPTIONS] the-question [the-answer]
-
-This is a demo app to showcase some features of args
-
-Arguments:
-  the-question   Before you have an answer
-  the-answer     It must be 42
-
-Options:
-  +c, ++config-file   path to config file (Default=/path/to/config)
-  -m, --message       send a message (Default=over-ten-thousand Env=MESSAGE)
-  -s, --slice         list of messages (Default=one,two,three Env=LIST)
-  -v, --verbose       be verbose
-  -d, --debug         turn on Debug
-  -h, --help          show this help message
-  -p, --power-level   set our power level (Default=10000 Env=POWER_LEVEL)
-  -dH, --host         database hostname (Default=localhost)
-
-```
 
 ## Stuff that works
 * Support list of strings '--list my,list,of,things'
@@ -494,17 +249,17 @@ Options:
 * Support for escaping arguments (IE: --help and \\-\\-help are different)
 * Automatically generates help for SubCommands
 * Tests for args.WatchFile()
+* Support list of strings '--list my,list,of,things'
+* Support map type '--map={1:"thing", 2:"thing"}'
+* Support Greedy Arguments ```[<files>….]```
+* Support Parent Parsing
 * Support for Kubernetes ConfigMap file watching
 
 ## TODO
 * Custom Help and Usage
 * Support counting arguments in this format -vvvv
-* Support list of ints,floats,etc.. '--list my,list,of,things'
-* Support map type '--map={1:"thing", 2:"thing"}'
 * Support float type '--float=3.14'
 * Support '-arg=value'
-* Support Parent Parsing
-* Support Greedy Arguments ```[<files>….]```
 * Write better intro document
 * Write godoc
 * Ability to include Config() options in help message

--- a/backends_test.go
+++ b/backends_test.go
@@ -23,7 +23,7 @@ type TestBackend struct {
 func NewTestBackend() args.Backend {
 	return &TestBackend{
 		keys: map[string]args.Pair{
-			"/root/DEFAULT/bind": args.Pair{Key: "bind", Value: []byte("thrawn01.org:3366")}},
+			"/root/bind": args.Pair{Key: "bind", Value: []byte("thrawn01.org:3366")}},
 		lists: map[string][]args.Pair{
 			"/root/endpoints": []args.Pair{
 				args.Pair{Key: "endpoint1", Value: []byte("http://endpoint1.com:3366")},

--- a/examples/chicken-cli/checkin-cli.go
+++ b/examples/chicken-cli/checkin-cli.go
@@ -30,7 +30,7 @@ func main() {
 	parser.AddOption("--endpoint").Default("http://localhost:1234").Env("API_ENDPOINT").
 		Help("The HTTP endpoint our client will talk too")
 
-	parser.AddCommand("super-chickens", func(subParser *args.ArgParser, data interface{}) int {
+	parser.AddCommand("super-chickens", func(subParser *args.ArgParser, data interface{}) (int, error) {
 		subParser.AddCommand("create", createChickens)
 		subParser.AddCommand("list", listChickens)
 		subParser.AddCommand("delete", deleteChickens)
@@ -42,10 +42,9 @@ func main() {
 		// Run the sub-commands
 		retCode, err := subParser.ParseAndRun(nil, data)
 		if err != nil {
-			fmt.Println(err.Error())
-			return 1
+			return 1, err
 		}
-		return retCode
+		return retCode, nil
 	})
 
 	// Add our non super chicken actions
@@ -54,7 +53,7 @@ func main() {
 	parser.AddCommand("delete", deleteChickens)
 
 	// Parse the command line
-	opts, err := parser.ParseArgs(nil)
+	opts, err := parser.Parse(nil)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
@@ -80,12 +79,11 @@ func main() {
 	os.Exit(retCode)
 }
 
-func createChickens(subParser *args.ArgParser, data interface{}) int {
+func createChickens(subParser *args.ArgParser, data interface{}) (int, error) {
 	subParser.AddArgument("name").Required().Help("The name of the chicken to create")
-	opts, err := subParser.ParseArgs(nil)
-	if err != nil {
-		fmt.Println(err.Error())
-		return 1
+	opts := subParser.ParseSimple(nil)
+	if opts == nil {
+		return 1, nil
 	}
 
 	shared := data.(*SharedStruct)
@@ -96,64 +94,57 @@ func createChickens(subParser *args.ArgParser, data interface{}) int {
 		"metadata": shared.Metadata,
 	})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "JSON Marshalling Error -", err)
-		return 1
+		return 1, errors.Wrap(err, "while marshalling JSON")
 	}
 
 	// Create the new Request
 	req, err := http.NewRequest("POST", joinUrl(shared, "chickens"), bytes.NewBuffer(payload))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		return 1
+		return 1, errors.Wrap(err, "while creating new http request")
 	}
 	resp, err := sendRequest(opts, req, &payload)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return 1
+		return 1, err
 	}
 	fmt.Println(resp)
-	return 0
+	return 0, nil
 }
 
-func listChickens(subParser *args.ArgParser, data interface{}) int {
+func listChickens(subParser *args.ArgParser, data interface{}) (int, error) {
 	opts := subParser.GetOpts()
 
 	shared := data.(*SharedStruct)
 	req, err := http.NewRequest("GET", joinUrl(shared, "chickens"), nil)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return 1
+		return 1, errors.Wrap(err, "while creating new http request")
 	}
 	resp, err := sendRequest(opts, req, nil)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return 1
+		return 1, err
 	}
 	fmt.Println(resp)
-	return 0
+	return 0, nil
 }
 
-func deleteChickens(subParser *args.ArgParser, data interface{}) int {
+func deleteChickens(subParser *args.ArgParser, data interface{}) (int, error) {
 	subParser.AddArgument("name").Required().Help("The name of the chicken to delete")
-	opts, err := subParser.ParseArgs(nil)
-	if err != nil {
-		fmt.Println(err.Error())
-		return 1
+	opts := subParser.ParseSimple(nil)
+	if opts == nil {
+		return 1, nil
 	}
 
 	shared := data.(*SharedStruct)
 	req, err := http.NewRequest("DELETE", joinUrl(shared, "chickens", opts.String("name")), nil)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return 1
+		return 1, errors.Wrap(err, "while creating new http request")
 	}
 	resp, err := sendRequest(opts, req, nil)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return 1
+		return 1, err
 	}
 	fmt.Println(resp)
-	return 0
+	return 0, nil
 }
 
 func joinUrl(shared *SharedStruct, slugs ...string) string {

--- a/examples/demo/demo.go
+++ b/examples/demo/demo.go
@@ -85,10 +85,10 @@ func main() {
 	db.AddConfig("pass").Help("database password")
 
 	// Pass our own argument list, or nil to parse os.Args[]
-	opt := parser.ParseArgsSimple(nil)
+	opt := parser.ParseOrExit(nil)
 
-	// NOTE: ParseArgsSimple() is just a convenience, you can call
-	// parser.ParseArgs(nil) directly and handle the errors
+	// NOTE: ParseOrExit() is just a convenience, you can call
+	// parser.Parse(nil) directly and handle the errors
 	// yourself if you have more complicated use case
 
 	// Demo default variables in a struct
@@ -98,13 +98,6 @@ func main() {
 	fmt.Printf("DbHost       '%s'\n", conf.DbHost)
 	fmt.Printf("TheAnswer    '%d'\n", conf.TheAnswer)
 	fmt.Println("")
-
-	// If user asked for --help or there were no options
-	// passed and none where required
-	if opt.NoArgs() || opt.Bool("help") {
-		parser.PrintHelp()
-		os.Exit(-1)
-	}
 
 	fmt.Println("")
 	fmt.Println("==================")

--- a/examples/watch/watch.go
+++ b/examples/watch/watch.go
@@ -33,7 +33,7 @@ func main() {
 	// that all edits are complete and the application can reload the config
 	parser.AddConfig("version").IsInt().Default("0").Help("config file version")
 
-	appConf, err := parser.ParseArgs(nil)
+	appConf, err := parser.Parse(nil)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(-1)

--- a/ini_test.go
+++ b/ini_test.go
@@ -29,7 +29,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddOption("--two").IsString()
 			parser.AddOption("--three").IsString()
 			cmdLine := []string{"--three", "this is three value"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			input := []byte("one=this is one value\ntwo=this is two value\n")
 			opt, err = parser.FromINI(input)
 			Expect(err).To(BeNil())
@@ -43,7 +43,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddOption("--two").IsString()
 			parser.AddOption("--three").IsString()
 			cmdLine := []string{"--three", "this is three value", "--one", "this is from the cmd line"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			input := []byte("one=this is one value\ntwo=this is two value\n")
 			opt, err = parser.FromINI(input)
 			Expect(err).To(BeNil())
@@ -56,7 +56,7 @@ var _ = Describe("ArgParser", func() {
 			var list []string
 			parser.AddOption("--list").StoreStringSlice(&list).Default("foo,bar,bit")
 
-			opt, err := parser.ParseArgs(nil)
+			opt, err := parser.Parse(nil)
 			Expect(err).To(BeNil())
 			Expect(opt.StringSlice("list")).To(Equal([]string{"foo", "bar", "bit"}))
 			Expect(list).To(Equal([]string{"foo", "bar", "bit"}))
@@ -81,7 +81,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddConfig("debug").InGroup("database").IsBool()
 
 			cmdLine := []string{"--debug"}
-			opts, err := parser.ParseArgs(&cmdLine)
+			opts, err := parser.Parse(&cmdLine)
 
 			iniFile := []byte(`
 				[database]
@@ -102,7 +102,7 @@ var _ = Describe("ArgParser", func() {
 
 			// 'two' is missing from the command line
 			cmdLine := []string{"--one", "this is one"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(opt.String("one")).To(Equal("this is one"))
 			Expect(opt.IsSet("one")).To(Equal(true))
 			Expect(opt.IsSet("two")).To(Equal(false))
@@ -133,7 +133,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddOption("--one").IsString()
 			parser.AddConfigGroup("candy-bars")
 
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(log.GetEntry()).To(Equal(""))
 			Expect(opt.String("one")).To(Equal("one-thing"))

--- a/parser_test.go
+++ b/parser_test.go
@@ -15,16 +15,16 @@ var _ = Describe("ArgParser", func() {
 		log = NewTestLogger()
 	})
 
-	Describe("ArgParser.ParseArgs(nil)", func() {
+	Describe("ArgParser.Parse(nil)", func() {
 		It("Should return error if AddOption() was never called", func() {
 			parser := args.NewParser(args.NoHelp())
-			_, err := parser.ParseArgs(nil)
+			_, err := parser.Parse(nil)
 			Expect(err).ToNot(BeNil())
-			Expect(err.Error()).To(Equal("Must create some options to match with args.AddOption() before calling arg.ParseArgs()"))
+			Expect(err.Error()).To(Equal("Must create some options to match with args.AddOption() before calling arg.Parse()"))
 		})
 		It("Should add Help option if none provided", func() {
 			parser := args.NewParser()
-			_, err := parser.ParseArgs(nil)
+			_, err := parser.Parse(nil)
 			Expect(err).To(BeNil())
 			rule := parser.GetRules()[0]
 			Expect(rule.Name).To(Equal("help"))
@@ -67,35 +67,35 @@ var _ = Describe("ArgParser", func() {
 		It("Should match --one", func() {
 			parser := args.NewParser()
 			parser.AddOption("--one").Count()
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Int("one")).To(Equal(1))
 		})
 		It("Should match -two", func() {
 			parser := args.NewParser()
 			parser.AddOption("-two").Count()
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Int("two")).To(Equal(1))
 		})
 		It("Should match ++three", func() {
 			parser := args.NewParser()
 			parser.AddOption("++three").Count()
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Int("three")).To(Equal(1))
 		})
 		It("Should match +four", func() {
 			parser := args.NewParser()
 			parser.AddOption("+four").Count()
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Int("four")).To(Equal(1))
 		})
 		It("Should match --power-level", func() {
 			parser := args.NewParser()
 			parser.AddOption("--power-level").Count()
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Int("power-level")).To(Equal(1))
 		})
@@ -103,7 +103,7 @@ var _ = Describe("ArgParser", func() {
 			parser := args.NewParser()
 			parser.AddOption("--power-level").Required()
 			cmdLine := []string{""}
-			_, err := parser.ParseArgs(&cmdLine)
+			_, err := parser.Parse(&cmdLine)
 
 			Expect(err).To(Not(BeNil()))
 			Expect(err.Error()).To(Equal("option '--power-level' is required"))
@@ -116,13 +116,13 @@ var _ = Describe("ArgParser", func() {
 			parser.AddOption("--list").IsStringSlice().Default("foo,bar,bit")
 
 			// Test Default Value
-			opt, err := parser.ParseArgs(nil)
+			opt, err := parser.Parse(nil)
 			Expect(err).To(BeNil())
 			Expect(opt.StringSlice("list")).To(Equal([]string{"foo", "bar", "bit"}))
 
 			// Provided on the command line
 			cmdLine := []string{"--list", "belt,car,table"}
-			opt, err = parser.ParseArgs(&cmdLine)
+			opt, err = parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.StringSlice("list")).To(Equal([]string{"belt", "car", "table"}))
 		})
@@ -132,7 +132,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddOption("--list").StoreStringSlice(&list).Default("foo,bar,bit")
 
 			cmdLine := []string{"--list", "belt,car,table"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.StringSlice("list")).To(Equal([]string{"belt", "car", "table"}))
 			Expect(list).To(Equal([]string{"belt", "car", "table"}))
@@ -142,7 +142,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddOption("--list").IsStringSlice()
 
 			cmdLine := []string{"--list", "bee", "--list", "cat", "--list", "dad"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.StringSlice("list")).To(Equal([]string{"bee", "cat", "dad"}))
 		})
@@ -152,7 +152,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddOption("--list").StoreStringSlice(&list)
 
 			cmdLine := []string{"--list", "bee", "--list", "cat", "--list", "dad"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.StringSlice("list")).To(Equal([]string{"bee", "cat", "dad"}))
 			Expect(list).To(Equal([]string{"bee", "cat", "dad"}))
@@ -162,7 +162,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddArgument("list").IsStringSlice()
 
 			cmdLine := []string{"bee", "cat", "dad"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.StringSlice("list")).To(Equal([]string{"bee", "cat", "dad"}))
 		})
@@ -197,7 +197,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddOption("--foo")
 
 			cmdLine := []string{"--map", "http.ip=192.168.1.1"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(opt.StringMap("map")).To(Equal(map[string]string{"http.ip": "192.168.1.1"}))
 			Expect(err).To(BeNil())
 		})
@@ -207,7 +207,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddOption("--foo")
 
 			cmdLine := []string{"--map", `http\=ip=192.168.1.1`}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.StringMap("map")).To(Equal(map[string]string{"http=ip": "192.168.1.1"}))
 		})
@@ -216,7 +216,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddOption("--list").IsStringMap()
 			parser.AddOption("--foo")
 
-			_, err := parser.ParseArgs(nil)
+			_, err := parser.Parse(nil)
 			Expect(err).To(BeNil())
 		})
 		It("Should allow string map with '=' expression in a comma delimited string", func() {
@@ -224,7 +224,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddOption("--map").IsStringMap().Default("foo=bar,bar=foo")
 
 			// Test Default Value
-			opt, err := parser.ParseArgs(nil)
+			opt, err := parser.Parse(nil)
 			Expect(opt).To(Not(BeNil()))
 
 			Expect(err).To(BeNil())
@@ -232,7 +232,7 @@ var _ = Describe("ArgParser", func() {
 
 			// Provided on the command line
 			cmdLine := []string{"--map", "belt=car,table=cloth"}
-			opt, err = parser.ParseArgs(&cmdLine)
+			opt, err = parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.StringMap("map")).To(Equal(map[string]string{"belt": "car", "table": "cloth"}))
 		})
@@ -242,7 +242,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddOption("--map").StoreStringMap(&destMap).Default("foo=bar,bar=foo")
 
 			// Test Default Value
-			opt, err := parser.ParseArgs(nil)
+			opt, err := parser.Parse(nil)
 			Expect(opt).To(Not(BeNil()))
 
 			Expect(err).To(BeNil())
@@ -250,7 +250,7 @@ var _ = Describe("ArgParser", func() {
 
 			// Provided on the command line
 			cmdLine := []string{"--map", "belt=car,table=cloth"}
-			opt, err = parser.ParseArgs(&cmdLine)
+			opt, err = parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(destMap).To(Equal(map[string]string{"belt": "car", "table": "cloth"}))
 		})
@@ -259,13 +259,13 @@ var _ = Describe("ArgParser", func() {
 			parser.AddOption("--map").IsStringMap().Default(`{"foo":"bar", "bar":"foo"}`)
 
 			// Test Default Value
-			opt, err := parser.ParseArgs(nil)
+			opt, err := parser.Parse(nil)
 			Expect(err).To(BeNil())
 			Expect(opt.StringMap("map")).To(Equal(map[string]string{"foo": "bar", "bar": "foo"}))
 
 			// Provided on the command line
 			cmdLine := []string{"--map", `{"belt":"car","table":"cloth"}`}
-			opt, err = parser.ParseArgs(&cmdLine)
+			opt, err = parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.StringMap("map")).To(Equal(map[string]string{"belt": "car", "table": "cloth"}))
 		})
@@ -274,7 +274,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddOption("--map").IsStringMap()
 
 			cmdLine := []string{"--map", "blue=bell", "--map", "cat=dog", "--map", "dad=boy"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.StringMap("map")).To(Equal(map[string]string{
 				"blue": "bell",
@@ -312,19 +312,19 @@ var _ = Describe("ArgParser", func() {
 			parser.AddOption("--map").IsStringMap()
 
 			cmdLine := []string{"--map", "belt"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(Not(BeNil()))
 
 			cmdLine = []string{"--map", "belt="}
-			opt, err = parser.ParseArgs(&cmdLine)
+			opt, err = parser.Parse(&cmdLine)
 			Expect(err).To(Not(BeNil()))
 
 			cmdLine = []string{"--map", "belt=blue;,"}
-			opt, err = parser.ParseArgs(&cmdLine)
+			opt, err = parser.Parse(&cmdLine)
 			Expect(err).To(Not(BeNil()))
 
 			cmdLine = []string{"--map", "belt=car,table=cloth"}
-			opt, err = parser.ParseArgs(&cmdLine)
+			opt, err = parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.StringMap("map")).To(Equal(map[string]string{"belt": "car", "table": "cloth"}))
 		})
@@ -338,7 +338,7 @@ var _ = Describe("ArgParser", func() {
 				"--map", `{"cat":"dog"}`,
 				"--map", `{"dad":"boy"}`,
 			}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.StringMap("map")).To(Equal(map[string]string{
 				"blue": "bell",
@@ -362,23 +362,35 @@ var _ = Describe("ArgParser", func() {
 		It("Should match first argument 'one'", func() {
 			parser := args.NewParser()
 			parser.AddArgument("first").IsString()
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.String("first")).To(Equal("one"))
+		})
+	})
+	Describe("ArgParser.ModifyRule()", func() {
+		It("Should return allow user to modify an existing rule ", func() {
+			parser := args.NewParser()
+			parser.AddOption("first").IsString().Default("one")
+			opt, err := parser.Parse(nil)
+			Expect(err).To(BeNil())
+			Expect(opt.String("first")).To(Equal("one"))
+			// Modify the rule and parse again
+			parser.ModifyRule("first").Default("two")
+			opt, err = parser.Parse(nil)
+			Expect(err).To(BeNil())
+			Expect(opt.String("first")).To(Equal("two"))
 		})
 	})
 	Describe("ArgParser.GetRule()", func() {
 		It("Should return allow user to modify an existing rule ", func() {
 			parser := args.NewParser()
 			parser.AddOption("first").IsString().Default("one")
-			opt, err := parser.ParseArgs(nil)
+			opt, err := parser.Parse(nil)
 			Expect(err).To(BeNil())
 			Expect(opt.String("first")).To(Equal("one"))
-			// Modify the rule and parse again
-			parser.GetRule("first").Default("two")
-			opt, err = parser.ParseArgs(nil)
-			Expect(err).To(BeNil())
-			Expect(opt.String("first")).To(Equal("two"))
+			// Get the rule
+			rule := parser.GetRule("first")
+			Expect(rule.Name).To(Equal("first"))
 		})
 	})
 
@@ -395,7 +407,7 @@ var _ = Describe("ArgParser", func() {
 		It("Should match first argument 'one'", func() {
 			parser := args.NewParser()
 			parser.AddArgument("first").IsString()
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.String("first")).To(Equal("one"))
 		})
@@ -404,7 +416,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddArgument("first").IsString()
 			parser.AddArgument("second").IsString()
 			parser.AddArgument("third").IsString()
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.String("first")).To(Equal("one"))
 			Expect(opt.String("second")).To(Equal("two"))
@@ -417,7 +429,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddArgument("third").IsString()
 
 			cmdLine := []string{"one", "two"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.String("first")).To(Equal("one"))
 			Expect(opt.String("second")).To(Equal("two"))
@@ -431,7 +443,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddArgument("third").IsString()
 
 			cmdLine := []string{"--first", "one", "two", "--verbose"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.String("first")).To(Equal("one"))
 			Expect(opt.String("second")).To(Equal("two"))
@@ -444,7 +456,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddArgument("first").IsString()
 
 			cmdLine := []string{"--first", "one", "one"}
-			_, err := parser.ParseArgs(&cmdLine)
+			_, err := parser.Parse(&cmdLine)
 			Expect(err).To(Not(BeNil()))
 			Expect(err.Error()).To(Equal("Duplicate option 'first' defined"))
 		})
@@ -453,7 +465,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddOption("--debug").IsTrue()
 			parser.AddConfig("debug").IsBool()
 
-			_, err := parser.ParseArgs(nil)
+			_, err := parser.Parse(nil)
 			Expect(err).To(Not(BeNil()))
 			Expect(err.Error()).To(Equal("Duplicate option 'debug' defined"))
 		})
@@ -463,7 +475,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddArgument("second").Required()
 
 			cmdLine := []string{"one"}
-			_, err := parser.ParseArgs(&cmdLine)
+			_, err := parser.Parse(&cmdLine)
 			Expect(err).To(Not(BeNil()))
 			Expect(err.Error()).To(Equal("argument 'second' is required"))
 		})
@@ -473,7 +485,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddArgument("second")
 
 			cmdLine := []string{"one"}
-			_, err := parser.ParseArgs(&cmdLine)
+			_, err := parser.Parse(&cmdLine)
 			Expect(err).To(Not(BeNil()))
 			Expect(err.Error()).To(Equal("'second' is ambiguous when " +
 				"following greedy argument 'first'"))
@@ -484,7 +496,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddArgument("second").IsStringSlice()
 
 			cmdLine := []string{"one"}
-			_, err := parser.ParseArgs(&cmdLine)
+			_, err := parser.Parse(&cmdLine)
 			Expect(err).To(Not(BeNil()))
 			Expect(err.Error()).To(Equal("'second' is ambiguous when " +
 				"following greedy argument 'first'"))
@@ -497,7 +509,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddConfig("power-level").Count().Help("My help message")
 
 			// Should ignore command line options
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Int("power-level")).To(Equal(0))
 
@@ -519,7 +531,7 @@ var _ = Describe("ArgParser", func() {
 			parser := args.NewParser()
 			parser.AddOption("--power-level").Count()
 			parser.InGroup("database").AddOption("--hostname")
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Int("power-level")).To(Equal(1))
 			Expect(opt.Group("database").String("hostname")).To(Equal("mysql.com"))
@@ -531,7 +543,7 @@ var _ = Describe("ArgParser", func() {
 			parser := args.NewParser()
 			rule := args.NewRuleModifier(parser).Count().Help("My help message")
 			parser.AddRule("--power-level", rule)
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Int("power-level")).To(Equal(2))
 		})
@@ -585,9 +597,9 @@ var _ = Describe("ArgParser", func() {
 		It("Should run a command if seen on the command line", func() {
 			parser := args.NewParser()
 			called := false
-			parser.AddCommand("command1", func(parent *args.ArgParser, data interface{}) int {
+			parser.AddCommand("command1", func(parent *args.ArgParser, data interface{}) (int, error) {
 				called = true
-				return 0
+				return 0, nil
 			})
 			cmdLine := []string{"command1"}
 			retCode, err := parser.ParseAndRun(&cmdLine, nil)
@@ -598,9 +610,9 @@ var _ = Describe("ArgParser", func() {
 		It("Should not confuse a command with a following argument", func() {
 			parser := args.NewParser()
 			called := 0
-			parser.AddCommand("set", func(parent *args.ArgParser, data interface{}) int {
+			parser.AddCommand("set", func(parent *args.ArgParser, data interface{}) (int, error) {
 				called++
-				return 0
+				return 0, nil
 			})
 			cmdLine := []string{"set", "set"}
 			retCode, err := parser.ParseAndRun(&cmdLine, nil)
@@ -611,16 +623,16 @@ var _ = Describe("ArgParser", func() {
 		It("Should provide a sub parser with that will not confuse a following argument", func() {
 			parser := args.NewParser()
 			called := 0
-			parser.AddCommand("set", func(parent *args.ArgParser, data interface{}) int {
+			parser.AddCommand("set", func(parent *args.ArgParser, data interface{}) (int, error) {
 				parent.AddArgument("first").Required()
 				parent.AddArgument("second").Required()
-				opts, err := parent.ParseArgs(nil)
+				opts, err := parent.Parse(nil)
 				Expect(err).To(BeNil())
 				Expect(opts.String("first")).To(Equal("foo"))
 				Expect(opts.String("second")).To(Equal("bar"))
 
 				called++
-				return 0
+				return 0, nil
 			})
 			cmdLine := []string{"set", "foo", "bar"}
 			retCode, err := parser.ParseAndRun(&cmdLine, nil)
@@ -632,20 +644,20 @@ var _ = Describe("ArgParser", func() {
 		It("Should allow sub commands to be a thing", func() {
 			parser := args.NewParser()
 			called := 0
-			parser.AddCommand("volume", func(parent *args.ArgParser, data interface{}) int {
-				parent.AddCommand("create", func(subParent *args.ArgParser, data interface{}) int {
+			parser.AddCommand("volume", func(parent *args.ArgParser, data interface{}) (int, error) {
+				parent.AddCommand("create", func(subParent *args.ArgParser, data interface{}) (int, error) {
 					subParent.AddArgument("volume-name").Required()
-					opts, err := subParent.ParseArgs(nil)
+					opts, err := subParent.Parse(nil)
 					Expect(err).To(BeNil())
 					Expect(opts.String("volume-name")).To(Equal("my-new-volume"))
 
 					called++
-					return 0
+					return 0, nil
 				})
 				retCode, err := parent.ParseAndRun(nil, nil)
 				Expect(err).To(BeNil())
 				Expect(retCode).To(Equal(0))
-				return retCode
+				return retCode, nil
 			})
 			cmdLine := []string{"volume", "create", "my-new-volume"}
 			retCode, err := parser.ParseAndRun(&cmdLine, nil)
@@ -660,16 +672,17 @@ var _ = Describe("ArgParser", func() {
 			parser.HelpIO = ioWriter
 
 			called := 0
-			parser.AddCommand("set", func(parent *args.ArgParser, data interface{}) int {
+			parser.AddCommand("set", func(parent *args.ArgParser, data interface{}) (int, error) {
 				parent.AddArgument("first").Required()
-				_, err := parent.ParseArgs(nil)
+				_, err := parent.Parse(nil)
 				Expect(err).To(Not(BeNil()))
 				Expect(err.Error()).To(Equal("User asked for help; Inspect this error " +
 					"with args.AskedForHelp(err)"))
+				Expect(args.IsHelpError(err)).To(Equal(true))
 				Expect(args.AskedForHelp(err)).To(Equal(true))
 
 				called++
-				return 0
+				return 0, nil
 			})
 			cmdLine := []string{"set", "-h"}
 			retCode, err := parser.ParseAndRun(&cmdLine, nil)
@@ -687,7 +700,7 @@ var _ = Describe("ArgParser", func() {
 
 			cmdLine := []string{"golang:1.6", "build", "-o",
 				"amd64-my-prog", "-installsuffix", "static", "./..."}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.String("output")).To(Equal("amd64-my-prog"))
 			Expect(opt.String("image")).To(Equal("golang:1.6"))
@@ -698,7 +711,7 @@ var _ = Describe("ArgParser", func() {
 			parser.AddOption("--list").IsStringSlice()
 
 			cmdLine := []string{"--list", "bee", "--list", "cat", "--list", "dad"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.StringSlice("list")).To(Equal([]string{"bee", "cat", "dad"}))
 			Expect(parser.GetArgs()).To(Equal([]string{}))

--- a/rule_modifier_test.go
+++ b/rule_modifier_test.go
@@ -20,7 +20,7 @@ var _ = Describe("RuleModifier", func() {
 			db.AddConfig("pass").Help("database password")
 
 			// Should ignore command line options
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Int("power-level")).To(Equal(0))
 
@@ -46,7 +46,7 @@ var _ = Describe("RuleModifier", func() {
 			parser := args.NewParser()
 			parser.AddOption("--power-level").Count()
 			parser.AddOption("--hostname").InGroup("database")
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Int("power-level")).To(Equal(1))
 			Expect(opt.Group("database").String("hostname")).To(Equal("mysql.com"))
@@ -57,7 +57,7 @@ var _ = Describe("RuleModifier", func() {
 			db.AddOption("--host").Alias("-dH").Default("localhost")
 			db.AddConfig("debug").IsTrue()
 
-			_, err := parser.ParseArgs(nil)
+			_, err := parser.Parse(nil)
 			Expect(err).To(BeNil())
 
 			rule := parser.GetRules()[0]
@@ -97,7 +97,7 @@ var _ = Describe("RuleModifier", func() {
 			parser := args.NewParser()
 			cmdLine := []string{"--verbose"}
 			parser.AddOption("--verbose").Count()
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Int("verbose")).To(Equal(1))
 		})
@@ -105,7 +105,7 @@ var _ = Describe("RuleModifier", func() {
 			parser := args.NewParser()
 			cmdLine := []string{"--verbose", "--verbose", "--verbose"}
 			parser.AddOption("--verbose").Count()
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Int("verbose")).To(Equal(3))
 		})
@@ -116,7 +116,7 @@ var _ = Describe("RuleModifier", func() {
 			parser.AddOption("--power-level").IsInt()
 
 			cmdLine := []string{"--power-level", "10000"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Int("power-level")).To(Equal(10000))
 		})
@@ -125,7 +125,7 @@ var _ = Describe("RuleModifier", func() {
 			parser := args.NewParser()
 			cmdLine := []string{"--power-level", "over-ten-thousand"}
 			parser.AddOption("--power-level").IsInt()
-			_, err := parser.ParseArgs(&cmdLine)
+			_, err := parser.Parse(&cmdLine)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(Equal("Invalid value for '--power-level' - 'over-ten-thousand' is not an Integer"))
 			//Expect(opt.Int("power-level")).To(Equal(0))
@@ -135,7 +135,7 @@ var _ = Describe("RuleModifier", func() {
 			parser := args.NewParser()
 			cmdLine := []string{"--power-level"}
 			parser.AddOption("--power-level").IsInt()
-			_, err := parser.ParseArgs(&cmdLine)
+			_, err := parser.Parse(&cmdLine)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(Equal("Expected '--power-level' to have an argument"))
 			//Expect(opt.Int("power-level")).To(Equal(0))
@@ -148,7 +148,7 @@ var _ = Describe("RuleModifier", func() {
 			parser.AddOption("--power-level").StoreInt(&value)
 
 			cmdLine := []string{"--power-level", "10000"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Int("power-level")).To(Equal(10000))
 			Expect(value).To(Equal(10000))
@@ -160,7 +160,7 @@ var _ = Describe("RuleModifier", func() {
 			parser.AddOption("--power-level").IsString()
 
 			cmdLine := []string{"--power-level", "over-ten-thousand"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.String("power-level")).To(Equal("over-ten-thousand"))
 		})
@@ -169,7 +169,7 @@ var _ = Describe("RuleModifier", func() {
 			parser := args.NewParser()
 			cmdLine := []string{"--power-level"}
 			parser.AddOption("--power-level").IsString()
-			_, err := parser.ParseArgs(&cmdLine)
+			_, err := parser.Parse(&cmdLine)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(Equal("Expected '--power-level' to have an argument"))
 		})
@@ -181,7 +181,7 @@ var _ = Describe("RuleModifier", func() {
 			parser.AddOption("--power-level").StoreString(&value)
 
 			cmdLine := []string{"--power-level", "over-ten-thousand"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.String("power-level")).To(Equal("over-ten-thousand"))
 			Expect(value).To(Equal("over-ten-thousand"))
@@ -194,7 +194,7 @@ var _ = Describe("RuleModifier", func() {
 			parser.AddOption("--power-level").StoreStr(&value)
 
 			cmdLine := []string{"--power-level", "over-ten-thousand"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.String("power-level")).To(Equal("over-ten-thousand"))
 			Expect(value).To(Equal("over-ten-thousand"))
@@ -207,7 +207,7 @@ var _ = Describe("RuleModifier", func() {
 			parser.AddOption("--debug").StoreTrue(&debug)
 
 			cmdLine := []string{"--debug"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Bool("debug")).To(Equal(true))
 			Expect(debug).To(Equal(true))
@@ -219,7 +219,7 @@ var _ = Describe("RuleModifier", func() {
 			parser.AddOption("--debug").StoreTrue(&debug)
 
 			cmdLine := []string{"--something-else"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Bool("debug")).To(Equal(false))
 			Expect(debug).To(Equal(false))
@@ -231,7 +231,7 @@ var _ = Describe("RuleModifier", func() {
 			parser.AddOption("--help").IsTrue()
 
 			cmdLine := []string{"--help"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Bool("help")).To(Equal(true))
 		})
@@ -240,7 +240,7 @@ var _ = Describe("RuleModifier", func() {
 			parser := args.NewParser()
 			cmdLine := []string{"--something-else"}
 			parser.AddOption("--help").IsTrue()
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.Bool("help")).To(Equal(false))
 		})
@@ -251,7 +251,7 @@ var _ = Describe("RuleModifier", func() {
 			parser.AddOption("--list").IsStringSlice()
 
 			cmdLine := []string{"--list", "one,two,three"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.StringSlice("list")).To(Equal([]string{"one", "two", "three"}))
 		})
@@ -263,7 +263,7 @@ var _ = Describe("RuleModifier", func() {
 			parser.AddOption("--list").StoreStringSlice(&list)
 
 			cmdLine := []string{"--list", "one,two,three"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.StringSlice("list")).To(Equal([]string{"one", "two", "three"}))
 			Expect(list).To(Equal([]string{"one", "two", "three"}))
@@ -275,7 +275,7 @@ var _ = Describe("RuleModifier", func() {
 			parser.AddOption("--list").StoreStringSlice(&list)
 
 			cmdLine := []string{"--list", "one,two,three"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.StringSlice("list")).To(Equal([]string{"one", "two", "three"}))
 			Expect(list).To(Equal([]string{"one", "two", "three"}))
@@ -287,7 +287,7 @@ var _ = Describe("RuleModifier", func() {
 			parser.AddOption("--list").StoreStringSlice(&list)
 
 			cmdLine := []string{"--list", "one"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.StringSlice("list")).To(Equal([]string{"one"}))
 			Expect(list).To(Equal([]string{"one"}))
@@ -299,7 +299,7 @@ var _ = Describe("RuleModifier", func() {
 			parser.AddOption("--list").StoreStringSlice(&list)
 
 			cmdLine := []string{"--list"}
-			_, err := parser.ParseArgs(&cmdLine)
+			_, err := parser.Parse(&cmdLine)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(Equal("Expected '--list' to have an argument"))
 		})
@@ -311,7 +311,7 @@ var _ = Describe("RuleModifier", func() {
 			var value int
 			parser.AddOption("--power-level").StoreInt(&value).Default("10")
 
-			opt, err := parser.ParseArgs(nil)
+			opt, err := parser.Parse(nil)
 			Expect(err).To(BeNil())
 			Expect(opt.Int("power-level")).To(Equal(10))
 			Expect(value).To(Equal(10))
@@ -320,7 +320,7 @@ var _ = Describe("RuleModifier", func() {
 		It("Should return err if default value does not match AddOption() type", func() {
 			parser := args.NewParser()
 			parser.AddOption("--power-level").IsInt().Default("over-ten-thousand")
-			_, err := parser.ParseArgs(nil)
+			_, err := parser.Parse(nil)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(ContainSubstring("Bad default value"))
 		})
@@ -330,7 +330,7 @@ var _ = Describe("RuleModifier", func() {
 			parser := args.NewParser()
 			parser.AddOption("--choices").Choices([]string{"one", "two", "three"})
 
-			_, err := parser.ParseArgs(nil)
+			_, err := parser.Parse(nil)
 			Expect(err).To(Not(BeNil()))
 			Expect(err.Error()).To(Equal("option '--choices' is required"))
 		})
@@ -339,7 +339,7 @@ var _ = Describe("RuleModifier", func() {
 			parser.AddOption("--choices").Choices([]string{"one", "two", "three"})
 
 			cmdLine := []string{"--choices", "one"}
-			opt, err := parser.ParseArgs(&cmdLine)
+			opt, err := parser.Parse(&cmdLine)
 			Expect(err).To(BeNil())
 			Expect(opt.String("choices")).To(Equal("one"))
 		})
@@ -348,7 +348,7 @@ var _ = Describe("RuleModifier", func() {
 			parser.AddOption("--choices").Choices([]string{"one", "two", "three"})
 
 			cmdLine := []string{"--choices", "five"}
-			_, err := parser.ParseArgs(&cmdLine)
+			_, err := parser.Parse(&cmdLine)
 			Expect(err).To(Not(BeNil()))
 			Expect(err.Error()).To(Equal("'five' is an invalid argument for 'choices' " +
 				"choose from (one, two, three)"))
@@ -357,7 +357,7 @@ var _ = Describe("RuleModifier", func() {
 			parser := args.NewParser()
 			parser.AddOption("--choices").Default("two").Choices([]string{"one", "two", "three"})
 
-			opt, err := parser.ParseArgs(nil)
+			opt, err := parser.Parse(nil)
 			Expect(err).To(BeNil())
 			Expect(opt.String("choices")).To(Equal("two"))
 		})
@@ -366,7 +366,7 @@ var _ = Describe("RuleModifier", func() {
 			parser.AddOption("--choices").IsInt().Choices([]string{"1", "2", "3"})
 
 			cmdLine := []string{"--choices", "5"}
-			_, err := parser.ParseArgs(&cmdLine)
+			_, err := parser.Parse(&cmdLine)
 			Expect(err).To(Not(BeNil()))
 			Expect(err.Error()).To(Equal("'5' is an invalid argument for 'choices' " +
 				"choose from (1, 2, 3)"))
@@ -384,7 +384,7 @@ var _ = Describe("RuleModifier", func() {
 
 			os.Setenv("POWER_LEVEL", "10")
 
-			opt, err := parser.ParseArgs(nil)
+			opt, err := parser.Parse(nil)
 			Expect(err).To(BeNil())
 			Expect(opt.Int("power-level")).To(Equal(10))
 			Expect(value).To(Equal(10))
@@ -397,7 +397,7 @@ var _ = Describe("RuleModifier", func() {
 
 			os.Setenv("POWER_LEVEL", "over-ten-thousand")
 
-			_, err := parser.ParseArgs(nil)
+			_, err := parser.Parse(nil)
 			Expect(err).ToNot(BeNil())
 			Expect(err.Error()).To(Equal("Invalid value for 'POWER_LEVEL' - 'over-ten-thousand' is not an Integer"))
 		})
@@ -407,7 +407,7 @@ var _ = Describe("RuleModifier", func() {
 			var value int
 			parser.AddOption("--power-level").StoreInt(&value).Env("POWER_LEVEL").Default("1")
 
-			opt, err := parser.ParseArgs(nil)
+			opt, err := parser.Parse(nil)
 			Expect(err).To(BeNil())
 			Expect(opt.Int("power-level")).To(Equal(1))
 			Expect(value).To(Equal(1))

--- a/watchfile_test.go
+++ b/watchfile_test.go
@@ -45,7 +45,7 @@ var _ = Describe("args.WatchFile()", func() {
 		parser.AddConfig("value")
 		parser.AddConfig("version").IsInt()
 
-		opt, err := parser.ParseArgs(nil)
+		opt, err := parser.Parse(nil)
 		Expect(err).To(BeNil())
 		Expect(log.GetEntry()).To(Equal(""))
 		Expect(opt.String("value")).To(Equal(""))


### PR DESCRIPTION
## Implementation
* Renamed `GetRule()` to `ModifyRule()`
* Added `GetRule()` to return the actual rule named
* Renamed `ParseArgs` to `Parse`
* Renamed `ParseArgsSiimple` to `ParseSimple`
* Renamed `ParseArgsOrExit` to `ParseOrExit`
* Changed signature of `ParseSimple` which no longer will `os.Exit()`
* Changed how backends work
* Subcommand functions now return a `retCode` and an `error`\
* Added `StringToSlice` helper method
* Added `Options.FilePath` which will expand tilde if the strings begins with one
* Added `IsHelpError` for people who expect it to be called that.
* Backend keys no longer start with `/DEFAULT` if they don't have a group
* Argument errors no longer print help message by default.