### PR TITLE
-h now ignored by the root parser if a sub command is provided

### DIFF
--- a/examples/chicken-cli/checkin-cli.go
+++ b/examples/chicken-cli/checkin-cli.go
@@ -40,11 +40,7 @@ func main() {
 		shared.Metadata = "super"
 
 		// Run the sub-commands
-		retCode, err := subParser.ParseAndRun(nil, data)
-		if err != nil {
-			return 1, err
-		}
-		return retCode, nil
+		return subParser.ParseAndRun(nil, data)
 	})
 
 	// Add our non super chicken actions


### PR DESCRIPTION
## Purpose
In programs that `Parse()` args then `RunCommand` separately. Users that asked for help would only get the root parsers help message and not the sub command's help message.

## Implementation
* Parsers will set `help` to false if a sub command was also seen during parsing
* `Bool("help")` will return false if `--help` was requested by the user and a subcommand was also provided
* `WasSeen("help")` will always return true if `--help` was requested by the user