### PR TITLE
Added support for optional arguments with no specified prefix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.5
-  - 1.6
+  - 1.8
 
 # Setting sudo access to false will let Travis CI use containers rather than
 # VMs to run the tests. For more details see:

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ all: test examples
 travis-ci: get-deps
 	go get -u github.com/mattn/goveralls
 	go get -u golang.org/x/tools/cmd/cover
+	go get -u golang.org/x/text/encoding
 	goveralls -service=travis-ci
 
 $(GLIDE):

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ See more code examples in the ```examples/``` directory
 * Support Default Arguments
 * Support Reading arguments from an ini file
 * Support different types of optional prefixes (--, -, ++, +, etc..)
+* If AddOption() is called with a name that doesn’t begin with a prefix, apply some default rules to match - or -— prefix
 * Support for Config only options
 * Support for Groups
 * Support for Etcd v3 (See: https://github.com/thrawn01/args-backends)
@@ -263,5 +264,4 @@ See more code examples in the ```examples/``` directory
 * Write better intro document
 * Write godoc
 * Ability to include Config() options in help message
-* if AddOption() is called with a name that doesn’t begin with a prefix, apply some default rules to match - or — prefix
 * Add support for updating etcd values from the Option{} object. (shouldn't be hard)

--- a/parser.go
+++ b/parser.go
@@ -208,10 +208,15 @@ func (self *ArgParser) AddRule(name string, modifier *RuleModifier) *RuleModifie
 			rule.Name = group[2]
 		}
 	} else {
-		if rule.HasFlag(IsCommand) {
+		switch true {
+		case rule.HasFlag(IsCommand):
 			rule.Aliases = append(rule.Aliases, name)
 			rule.Name = fmt.Sprintf("!cmd-%s", name)
-		} else {
+		case rule.HasFlag(IsOption):
+			rule.Aliases = append(rule.Aliases, fmt.Sprintf("--%s", name))
+			rule.Aliases = append(rule.Aliases, fmt.Sprintf("-%s", name))
+			rule.Name = name
+		default:
 			rule.Name = name
 		}
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -99,6 +99,15 @@ var _ = Describe("ArgParser", func() {
 			Expect(err).To(BeNil())
 			Expect(opt.Int("power-level")).To(Equal(1))
 		})
+		It("Should match 'no-docker'", func() {
+			cmdLine := []string{"--no-docker"}
+
+			parser := args.NewParser()
+			parser.AddOption("no-docker").Count()
+			opt, err := parser.Parse(&cmdLine)
+			Expect(err).To(BeNil())
+			Expect(opt.Bool("no-docker")).To(Equal(true))
+		})
 		It("Should raise an error if a option is required but not provided", func() {
 			parser := args.NewParser()
 			parser.AddOption("--power-level").Required()


### PR DESCRIPTION
## Purpose
Support adding optional arguments without a prefix specified 
```go
parser.AddOption("no-prefix").IsTrue().
    Help("Will match -no-prefix and --no-prefix")
```
