### PR TITLE
StringToSlice now trims white space on each item in the slice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ $(GLIDE):
 get-deps: $(GLIDE)
 	$(GLIDE) install
 	go get -u golang.org/x/net/context
+	go get -u golang.org/x/text/encoding
 
 clean:
 	rm bin/*

--- a/args.go
+++ b/args.go
@@ -254,23 +254,28 @@ func castStringSlice(name string, dest interface{}, value interface{}) (interfac
 	}
 
 	// Assume the value must be a parsable string
-	return append(dest.([]string), StringToSlice(value.(string))...), nil
+	return append(dest.([]string), StringToSlice(value.(string), strings.TrimSpace)...), nil
 }
 
 // Given a comma separated string, return a slice of string items.
 // Return the entire string as the first item if no comma is found.
 //	// Returns []string{"one"}
 // 	result := args.StringToSlice("one")
+//
 //	// Returns []string{"one", "two", "three"}
-// 	result := args.StringToSlice("one,two,three")
-func StringToSlice(value string) []string {
-	// If no comma is found, then assume this is a single value
-	if strings.Index(value, ",") == -1 {
-		return []string{value}
+// 	result := args.StringToSlice("one, two, three", strings.TrimSpace)
+//
+//	// Returns []string{"ONE", "TWO", "THREE"}
+// 	result := args.StringToSlice("one, two, three", strings.ToUpper, strings.TrimSpace)
+func StringToSlice(value string, modifiers ...func(s string) string) []string {
+	result := strings.Split(value, ",")
+	// Apply the modifiers
+	for _, modifier := range modifiers {
+		for idx, item := range result {
+			result[idx] = modifier(item)
+		}
 	}
-
-	// Split the values separated by comma's
-	return strings.Split(value, ",")
+	return result
 }
 
 func mergeStringMap(src, dest map[string]string) map[string]string {

--- a/args_test.go
+++ b/args_test.go
@@ -2,6 +2,7 @@ package args_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -78,6 +79,21 @@ var _ = Describe("args", func() {
 		    est laborum.
 		    `, "\n")
 			Expect(text).To(Equal("Lorem ipsum dolor sit amet, consecteturadipiscing elit, sed\ndo eiusmod tempor incididunt ut labore etmollit anim id\nest laborum."))
+		})
+	})
+	Describe("args.StringSlice()", func() {
+		It("Should parse a simple comma separated line", func() {
+			result := args.StringToSlice("one,two,three")
+			Expect(result).To(Equal([]string{"one", "two", "three"}))
+
+			result = args.StringToSlice("one, two, three", strings.TrimSpace)
+			Expect(result).To(Equal([]string{"one", "two", "three"}))
+
+			result = args.StringToSlice("one, two, three", strings.TrimSpace, strings.ToUpper)
+			Expect(result).To(Equal([]string{"ONE", "TWO", "THREE"}))
+
+			result = args.StringToSlice("one", strings.TrimSpace, strings.ToUpper)
+			Expect(result).To(Equal([]string{"ONE"}))
 		})
 	})
 })


### PR DESCRIPTION
## Purpose
Allow users to trim and modify slice items during parse. Addresses  #39 

## Implementation
```go
// Returns []string{"one"}
result := args.StringToSlice("one")

// Returns []string{"one", "two", "three"}
result := args.StringToSlice("one, two, three", strings.TrimSpace)

// Returns []string{"ONE", "TWO", "THREE"}
result := args.StringToSlice("one, two, three", strings.ToUpper, strings.TrimSpace)
```